### PR TITLE
Update query format to support elasticsearch 5

### DIFF
--- a/query.go
+++ b/query.go
@@ -36,7 +36,7 @@ func queryUsingPlugin(p plugin, req queryRequest) (err error) {
 					"range": {
 						"utctimestamp": {
 							"gte": "%v",
-							"lte": "%v"
+							"lt": "%v"
 						}
 					}
 				}

--- a/query.go
+++ b/query.go
@@ -31,14 +31,14 @@ func queryUsingPlugin(p plugin, req queryRequest) (err error) {
 			"bool": {
 				"must": [
 				%v
-				]
-			}
-		},
-		"filter": {
-			"range": {
-				"utctimestamp": {
-					"from": "%v",
-					"to": "%v"
+				],
+				"filter": {
+					"range": {
+						"utctimestamp": {
+							"gte": "%v",
+							"lte": "%v"
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
We were getting query syntax errors when testing geomodel service on ES5, so this is the fix. This also is backwards compatible (works on ES2 and ES5)